### PR TITLE
feat: Add reference_sets functionality to rule_group

### DIFF
--- a/modules/rule-group/main.tf
+++ b/modules/rule-group/main.tf
@@ -24,6 +24,26 @@ resource "aws_networkfirewall_rule_group" "this" {
 
     content {
 
+      dynamic "reference_sets" {
+        for_each = try([rule_group.value.reference_sets], [])
+        content {
+
+          dynamic "ip_set_references" {
+            # One or more
+            for_each = try(reference_sets.value.ip_set_references, [])
+            content {
+              key = ip_set_references.value.key
+              dynamic "ip_set_reference" {
+                for_each = [ip_set_references.value.ip_set_reference]
+                content {
+                  reference_arn = ip_set_reference.value.definition
+                }
+              }
+            }
+          }
+        }
+      }
+
       dynamic "rule_variables" {
         for_each = try([rule_group.value.rule_variables], [])
         content {

--- a/modules/rule-group/main.tf
+++ b/modules/rule-group/main.tf
@@ -26,17 +26,20 @@ resource "aws_networkfirewall_rule_group" "this" {
 
       dynamic "reference_sets" {
         for_each = try([rule_group.value.reference_sets], [])
-        content {
 
+        content {
           dynamic "ip_set_references" {
             # One or more
             for_each = try(reference_sets.value.ip_set_references, [])
+
             content {
               key = ip_set_references.value.key
+
               dynamic "ip_set_reference" {
-                for_each = [ip_set_references.value.ip_set_reference]
+                for_each = [ip_set_references.value.reference_arn]
+                
                 content {
-                  reference_arn = ip_set_reference.value.definition
+                  reference_arn = ip_set_reference.value
                 }
               }
             }


### PR DESCRIPTION
Adding missing functionality as per Terraform docs: https://registry.terraform.io/providers/hashicorp/aws/5.80.0/docs/resources/networkfirewall_rule_group#reference_sets-3

For provider 5.2.0: 
https://registry.terraform.io/providers/hashicorp/aws/5.2.0/docs/resources/networkfirewall_rule_group#reference_sets-1

## Description

This PR introduces functionality to create IP Sets which permits references to VPC prefix lists. An IP Set can then be referenced in a rule in the rule group as outlined in the AWS Documentation here: https://docs.aws.amazon.com/network-firewall/latest/developerguide/suricata-examples.html#suricata-example-rule-with-ip-set-reference

## Motivation and Context

As per the description, we can create IP Sets which permit references to AWS Prefix Lists and then references the IP Set in the rule.

## Breaking Changes

This has been available for a considerable time and is available in provider versions 5.2 and greater which is the version pinned on this repository. 

## How Has This Been Tested?
- Testing with reference sets and without 

```
resource "aws_ec2_managed_prefix_list" "this" {
  name           = "All IPs"
  address_family = "IPv4"
  max_entries    = 3

  entry {
    cidr        = "10.60.0.0/16"
    description = "Primary"
  }

  entry {
    cidr        = "172.60.0.0/16"
    description = "Secondary"
  }
}

module "network_firewall_rule_group_stateful" {
  source = "terraform-aws-modules/network-firewall/aws//modules/rule-group"

  name        = "${local.name}-stateful"
  description = "Rule group to permit TCP 443 egress to IPs in prefixlist"
  type        = "STATEFUL"
  capacity    = 100
  
  rule_group = {

    reference_sets = {
      ip_set_references = [
        {
          key = "myipset"
          reference_arn = aws_ec2_managed_prefix_list.this[0].arn
        },
        {
          key = "myipsettwo"
          reference_arn = aws_ec2_managed_prefix_list.this[1].arn
        }
      ]
    }

    rules_source = {
      stateful_rule = [{
        action = "PASS"
        header = {
          destination      = "@myipset"
          destination_port = "443"
          direction        = "FORWARD"
          protocol         = "TCP"
          source           = "ANY"
          source_port      = "ANY"
        }

        rule_option = [{
          keyword  = "sid"
          settings = ["1"]
        }]
        }
      ]
    }

    stateful_rule_options = {
      rule_order = "STRICT_ORDER"
    }
  }

  # Resource Policy
  create_resource_policy     = true
  attach_resource_policy     = true
  resource_policy_principals = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
}
```

<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

