### PR TITLE
feat: Add Conditional Support for policy_variables in Policy Module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,9 @@ module "policy" {
   stateless_fragment_default_actions = var.policy_stateless_fragment_default_actions
   stateless_rule_group_reference     = var.policy_stateless_rule_group_reference
   name                               = try(coalesce(var.policy_name, var.name), "")
+  policy_variable_enabled            = var.policy_variable_enabled
+  rule_variable_key                  = var.policy_rule_variable_key
+  rule_variable_definition           = var.policy_rule_variable_definition
 
   # Resource policy
   create_resource_policy     = var.create_policy_resource_policy

--- a/modules/policy/main.tf
+++ b/modules/policy/main.tf
@@ -17,6 +17,20 @@ resource "aws_networkfirewall_firewall_policy" "this" {
   }
 
   firewall_policy {
+
+    # Create the policy_variables
+    dynamic "policy_variables" {
+      for_each = var.policy_variable_enabled ? [1] : []
+      content {
+        rule_variables {
+          key = var.rule_variable_key
+          ip_set {
+            definition = var.rule_variable_definition
+          }
+        }
+      }
+    }
+
     # Stateful
     stateful_default_actions = var.stateful_default_actions
 

--- a/modules/policy/variables.tf
+++ b/modules/policy/variables.tf
@@ -74,6 +74,25 @@ variable "name" {
   default     = ""
 }
 
+variable "policy_variable_enabled" {
+  description = "Toggle to enable or disable the policy_variables block"
+  type        = bool
+  default     = false
+}
+
+variable "rule_variable_key" {
+  description = "Key for the rule_variables block (e.g., HOME_NET)"
+  type        = string
+  default     = null
+}
+
+variable "rule_variable_definition" {
+  description = "List of IP ranges to include in the rule"
+  type        = list(string)
+  default     = []
+}
+
+
 ################################################################################
 # Resource Policies
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -159,6 +159,24 @@ variable "policy_tags" {
   default     = {}
 }
 
+variable "policy_variable_enabled" {
+  description = "Toggle to enable or disable the policy_variables block"
+  type        = bool
+  default     = false
+}
+
+variable "policy_rule_variable_key" {
+  description = "Key for the rule_variables block (e.g., HOME_NET)"
+  type        = string
+  default     = null
+}
+
+variable "policy_rule_variable_definition" {
+  description = "List of IP ranges to include in the rule"
+  type        = list(string)
+  default     = []
+}
+
 # Resource Policy
 variable "create_policy_resource_policy" {
   description = "Controls if a resource policy should be created"


### PR DESCRIPTION
This PR introduces conditional support for the policy_variables block in the policy module. This allows users to enable or disable the policy_variables block dynamically based on input variables. Additionally, it adds the required variables to both the policy module and the main module to ensure seamless integration.

Changes in `modules/policy`

1. `main.tf`
Added a `dynamic` block for `policy_variables` that is created only if `policy_variable_enabled` is set to `true`.
The block includes:
`rule_variables` with a customizable key.
An `ip_set` for specifying a list of IP ranges.

2. `variables.tf`

Added new input variables:
`policy_variable_enabled` (boolean) - Toggles the creation of the policy_variables block.
`rule_variable_key` (string) - Specifies the key for rule_variables (e.g., HOME_NET).
`rule_variable_definition` (list of strings) - Specifies the IP ranges for the ip_set.

Changes in Main Module

1. `main.tf`
Passed the `policy_variable_enabled`, `policy_rule_variable_key`, and `policy_rule_variable_definition` variables to the policy module.


2. `variables.tf`
Added new input variables to match those in the policy module:
```
policy_variable_enabled
policy_rule_variable_key
policy_rule_variable_definition

```

Testing
Tested the updated policy module locally.
Confirmed that the `policy_variables` block is created only when `policy_variable_enabled` is true.
Verified that the input variables are correctly passed from the main module to the policy module.
