### PR TITLE
fix: Add required_providers to main module

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.2"
+    }
+  }
 }


### PR DESCRIPTION
## Description

Add missing `required_provider` in the main module to resolve the warning mentioned in #3 and #10.

## Motivation and Context

It solves an `init` warning that was put in place as part of backwards compatibility in Terraform 0.13, as explained by HashiCorp developer [here](https://discuss.hashicorp.com/t/no-explicit-declaration-for-local-provider/67828/2). The version constraint was copied from the `required_versions` found in all the submodules' versions.tf files.

## Breaking Changes

It should not be a breaking change. The main module already requires Terraform `>= 1.0` and the warning was added in v0.13.

## How Has This Been Tested?

After receiving the warning running `terraform init -backend=false` I edited _.terraform/modules/network_firewall/versions.tf_ and added the change and then reran the init command to confirm the warning is no longer displayed.
