### PR TITLE
feat(policy): Add tls_inspection_configuration_arn and enable_tls_session_holding support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,10 @@ module "policy" {
   stateless_rule_group_reference     = var.policy_stateless_rule_group_reference
   name                               = try(coalesce(var.policy_name, var.name), "")
 
+  # TLS Inspection
+  tls_inspection_configuration_arn = var.policy_tls_inspection_configuration_arn
+  enable_tls_session_holding       = var.policy_enable_tls_session_holding
+
   # Resource policy
   create_resource_policy     = var.create_policy_resource_policy
   resource_policy_actions    = var.policy_resource_policy_actions

--- a/modules/policy/main.tf
+++ b/modules/policy/main.tf
@@ -120,6 +120,9 @@ resource "aws_networkfirewall_firewall_policy" "this" {
         resource_arn = stateless_rule_group_reference.value.resource_arn
       }
     }
+
+    tls_inspection_configuration_arn = var.tls_inspection_configuration_arn
+    enable_tls_session_holding       = var.enable_tls_session_holding
   }
 
   name = var.name

--- a/modules/policy/variables.tf
+++ b/modules/policy/variables.tf
@@ -123,6 +123,18 @@ variable "name" {
   default     = ""
 }
 
+variable "tls_inspection_configuration_arn" {
+  description = "The ARN of the TLS inspection configuration to associate with the firewall policy"
+  type        = string
+  default     = null
+}
+
+variable "enable_tls_session_holding" {
+  description = "Whether to allow the firewall to hold TLS sessions to allow TLS traffic processing before downstream connection establishment. When set to `true`, adds latency — enable only if TLS.SNI rule groups are active in the policy"
+  type        = bool
+  default     = null
+}
+
 ################################################################################
 # Resource Policies
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -235,6 +235,18 @@ variable "policy_name" {
   default     = ""
 }
 
+variable "policy_tls_inspection_configuration_arn" {
+  description = "The ARN of the TLS inspection configuration to associate with the firewall policy"
+  type        = string
+  default     = null
+}
+
+variable "policy_enable_tls_session_holding" {
+  description = "Whether to allow the firewall to hold TLS sessions to allow TLS traffic processing before downstream connection establishment. When set to `true`, adds latency — enable only if TLS.SNI rule groups are active in the policy"
+  type        = bool
+  default     = null
+}
+
 variable "policy_tags" {
   description = "A map of tags to add to all resources"
   type        = map(string)


### PR DESCRIPTION
## Summary

Resolves #20

Exposes TLS inspection support in the `policy` submodule and root module. Previously, users were forced to manage `aws_networkfirewall_firewall_policy` outside the module entirely when they needed to attach a TLS inspection configuration (as tracked in #20).

## Changes

### `modules/policy/variables.tf`
- Add `tls_inspection_configuration_arn` — ARN of an `aws_networkfirewall_tls_inspection_configuration` to attach to the policy
- Add `enable_tls_session_holding` — controls TLS session holding before downstream connection establishment (adds latency; only needed when TLS.SNI rule groups are active)

### `modules/policy/main.tf`
- Pass both new attributes to the `aws_networkfirewall_firewall_policy` resource inside `firewall_policy {}`

### `variables.tf` (root module)
- Add `policy_tls_inspection_configuration_arn`
- Add `policy_enable_tls_session_holding`

### `main.tf` (root module)
- Wire the two new root variables through to the `module.policy` call

## AWS Provider Support
Both attributes have been available in the AWS Terraform provider since **v5.32.0**:
- `firewall_policy.tls_inspection_configuration_arn`
- `firewall_policy.enable_tls_session_holding`

## Usage Example
```hcl
module "network_firewall" {
  source  = "terraform-aws-modules/network-firewall/aws"
  version = "~> 2.0"

  # ... existing config ...

  policy_tls_inspection_configuration_arn = aws_networkfirewall_tls_inspection_configuration.this.arn
  policy_enable_tls_session_holding       = false
}
```